### PR TITLE
Add api routes to retrieve codes

### DIFF
--- a/backend/codes/views.py
+++ b/backend/codes/views.py
@@ -3,47 +3,18 @@ from .serializers import CodeSerializer
 from .models import Code
 
 
-class AllCodesViewSet(viewsets.ModelViewSet):
+class CodesViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.AllowAny]
     http_method_names = ['get', 'post']
     serializer_class = CodeSerializer
 
     def get_queryset(self):
-        queryset = Code.objects
-        return queryset
 
-class ExampleCodesViewSet(viewsets.ModelViewSet):
-    permission_classes = [permissions.AllowAny]
-    http_method_names = ['get', 'post']
-    serializer_class = CodeSerializer
-
-    def get_queryset(self):
-        queryset = Code.objects.filter(is_example=True)
-        return queryset
-
-class NonExampleCodesViewSet(viewsets.ModelViewSet):
-    permission_classes = [permissions.AllowAny]
-    http_method_names = ['get', 'post']
-    serializer_class = CodeSerializer
-
-    def get_queryset(self):
-        queryset = Code.objects.filter(is_example=False)
-        return queryset
-
-class ApprovedCodesViewSet(viewsets.ModelViewSet):
-    permission_classes = [permissions.AllowAny]
-    http_method_names = ['get', 'post']
-    serializer_class = CodeSerializer
-
-    def get_queryset(self):
-        queryset = Code.objects.filter(approved=True)
-        return queryset
-
-class UnapprovedCodesViewSet(viewsets.ModelViewSet):
-    permission_classes = [permissions.AllowAny]
-    http_method_names = ['get', 'post']
-    serializer_class = CodeSerializer
-
-    def get_queryset(self):
-        queryset = Code.objects.filter(approved=False)
+        queryset = Code.objects.all()
+        example = self.request.query_params.get('example')
+        approved = self.request.query_params.get('approved')
+        if example:
+            queryset = queryset.filter(is_example=example)
+        elif approved:
+            queryset = queryset.filter(approved=approved)
         return queryset

--- a/backend/codes/views.py
+++ b/backend/codes/views.py
@@ -3,11 +3,47 @@ from .serializers import CodeSerializer
 from .models import Code
 
 
-class CodeViewSet(viewsets.ModelViewSet):
+class AllCodesViewSet(viewsets.ModelViewSet):
+    permission_classes = [permissions.AllowAny]
+    http_method_names = ['get', 'post']
+    serializer_class = CodeSerializer
+
+    def get_queryset(self):
+        queryset = Code.objects
+        return queryset
+
+class ExampleCodesViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.AllowAny]
     http_method_names = ['get', 'post']
     serializer_class = CodeSerializer
 
     def get_queryset(self):
         queryset = Code.objects.filter(is_example=True)
+        return queryset
+
+class NonExampleCodesViewSet(viewsets.ModelViewSet):
+    permission_classes = [permissions.AllowAny]
+    http_method_names = ['get', 'post']
+    serializer_class = CodeSerializer
+
+    def get_queryset(self):
+        queryset = Code.objects.filter(is_example=False)
+        return queryset
+
+class ApprovedCodesViewSet(viewsets.ModelViewSet):
+    permission_classes = [permissions.AllowAny]
+    http_method_names = ['get', 'post']
+    serializer_class = CodeSerializer
+
+    def get_queryset(self):
+        queryset = Code.objects.filter(approved=True)
+        return queryset
+
+class UnapprovedCodesViewSet(viewsets.ModelViewSet):
+    permission_classes = [permissions.AllowAny]
+    http_method_names = ['get', 'post']
+    serializer_class = CodeSerializer
+
+    def get_queryset(self):
+        queryset = Code.objects.filter(approved=False)
         return queryset

--- a/backend/lights/urls.py
+++ b/backend/lights/urls.py
@@ -7,7 +7,11 @@ from .views import ping
 
 
 router = routers.DefaultRouter()
-router.register(r'code/?', codes_views.CodeViewSet, basename='code')
+router.register(r'codes/all', codes_views.AllCodesViewSet, basename='codes/all')
+router.register(r'codes/approved', codes_views.ApprovedCodesViewSet, basename='codes/approved')
+router.register(r'codes/unapproved', codes_views.UnapprovedCodesViewSet, basename='codes/unapproved')
+router.register(r'codes/example', codes_views.ExampleCodesViewSet, basename='codes/example')
+router.register(r'codes/nonexample', codes_views.NonExampleCodesViewSet, basename='codes/nonexample')
 
 
 urlpatterns = [

--- a/backend/lights/urls.py
+++ b/backend/lights/urls.py
@@ -7,12 +7,7 @@ from .views import ping
 
 
 router = routers.DefaultRouter()
-router.register(r'codes/all', codes_views.AllCodesViewSet, basename='codes/all')
-router.register(r'codes/approved', codes_views.ApprovedCodesViewSet, basename='codes/approved')
-router.register(r'codes/unapproved', codes_views.UnapprovedCodesViewSet, basename='codes/unapproved')
-router.register(r'codes/example', codes_views.ExampleCodesViewSet, basename='codes/example')
-router.register(r'codes/nonexample', codes_views.NonExampleCodesViewSet, basename='codes/nonexample')
-
+router.register(r'codes/?', codes_views.CodesViewSet, basename='codes')
 
 urlpatterns = [
     path('admin/', admin.site.urls),

--- a/backend/tests/codes/test_views.py
+++ b/backend/tests/codes/test_views.py
@@ -74,7 +74,7 @@ def test_get_single_code_no_example_filtering_by_example_true(client):
     code = factories.CodeFactory.create(is_example=False)
 
     url = reverse('codes-detail', args=(code.pk,))
-    response = client.get(url + "?example=True")
+    response = client.get(url, {'example': True})
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -97,7 +97,7 @@ def test_get_codes_list_no_examples_filtering_by_example_true(client):
     list_of_codes = factories.CodeFactory.create_batch(number_of_example_codes, is_example=False)
 
     url = reverse('codes-list')
-    response = client.get(url + "?example=True")
+    response = client.get(url, {'example': True})
 
     assert response.status_code == status.HTTP_200_OK
     assert len(response.data) == 0
@@ -111,7 +111,7 @@ def test_get_codes_list_mixed_filtering_by_example_true(client):
     list_of_codes_no_example = factories.CodeFactory.create_batch(number_of_no_example_codes, is_example=False)
 
     url = reverse('codes-list')
-    response = client.get(url + "?example=True")
+    response = client.get(url, {'example': True})
 
     assert response.status_code == status.HTTP_200_OK
     assert len(response.data) == number_of_example_codes

--- a/backend/tests/codes/test_views.py
+++ b/backend/tests/codes/test_views.py
@@ -16,7 +16,7 @@ from codes.models import Code
     ]
 )
 def test_add_code_created(client, data):
-    url = reverse('code-list')
+    url = reverse('codes-list')
     response = client.post(url, data)
 
     assert response.status_code == status.HTTP_201_CREATED
@@ -41,7 +41,7 @@ def test_add_code_created(client, data):
     ]
 )
 def test_add_code_bad_request(client, data):
-    url = reverse('code-list')
+    url = reverse('codes-list')
     response = client.post(url, data)
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -49,7 +49,7 @@ def test_add_code_bad_request(client, data):
 
 @pytest.mark.django_db
 def test_add_code_invalid_json(client):
-    url = reverse('code-list')
+    url = reverse('codes-list')
     response = client.post(
         url,
         {}
@@ -63,18 +63,18 @@ def test_get_single_code(client):
     code = factories.CodeFactory.create(is_example=True)
     assert Code.objects.count() == 1
 
-    url = reverse('code-detail', args=(code.pk,))
+    url = reverse('codes-detail', args=(code.pk,))
     response = client.get(url)
 
     assert response.status_code == status.HTTP_200_OK
 
 
 @pytest.mark.django_db
-def test_get_single_code_no_example(client):
+def test_get_single_code_no_example_filtering_by_example_true(client):
     code = factories.CodeFactory.create(is_example=False)
 
-    url = reverse('code-detail', args=(code.pk,))
-    response = client.get(url)
+    url = reverse('codes-detail', args=(code.pk,))
+    response = client.get(url + "?example=True")
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -84,7 +84,7 @@ def test_get_codes_list(client):
     number_of_example_codes = 4
     list_of_codes = factories.CodeFactory.create_batch(number_of_example_codes, is_example=True)
 
-    url = reverse('code-list')
+    url = reverse('codes-list')
     response = client.get(url)
 
     assert response.status_code == status.HTTP_200_OK
@@ -92,26 +92,26 @@ def test_get_codes_list(client):
 
 
 @pytest.mark.django_db
-def test_get_codes_list_no_examples(client):
+def test_get_codes_list_no_examples_filtering_by_example_true(client):
     number_of_example_codes = 4
     list_of_codes = factories.CodeFactory.create_batch(number_of_example_codes, is_example=False)
 
-    url = reverse('code-list')
-    response = client.get(url)
+    url = reverse('codes-list')
+    response = client.get(url + "?example=True")
 
     assert response.status_code == status.HTTP_200_OK
     assert len(response.data) == 0
 
 
 @pytest.mark.django_db
-def test_get_codes_list_mixed(client):
+def test_get_codes_list_mixed_filtering_by_example_true(client):
     number_of_example_codes = 4
     number_of_no_example_codes = 2
     list_of_codes_example = factories.CodeFactory.create_batch(number_of_example_codes, is_example=True)
     list_of_codes_no_example = factories.CodeFactory.create_batch(number_of_no_example_codes, is_example=False)
 
-    url = reverse('code-list')
-    response = client.get(url)
+    url = reverse('codes-list')
+    response = client.get(url + "?example=True")
 
     assert response.status_code == status.HTTP_200_OK
     assert len(response.data) == number_of_example_codes
@@ -122,7 +122,7 @@ def test_get_codes_list_big_number_of_codes(client):
     number_of_example_codes = 1000
     list_of_codes = factories.CodeFactory.create_batch(number_of_example_codes, is_example=True)
 
-    url = reverse('code-list')
+    url = reverse('codes-list')
     response = client.get(url)
 
     assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
Dodane ścieżki pozwalają za pomocą /api backendu wyciągnąć kody nas interesujące, np. `codes/all` - lista wszystkich kodów.