### PR TITLE
Force line endings in wait-for-it script to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+backend/wait-for-it.sh eol=lf


### PR DESCRIPTION
*Powinno* utrzymywać w tym skrypcie użycie LF jako znaku końca linii.
Autocrlf gita sprawia problemy z uruchomieniem tego skryptu w dockerze na Windowsie.
