### PR TITLE
Fix random color during fadeout_in

### DIFF
--- a/emulate/client_example.py
+++ b/emulate/client_example.py
@@ -3,7 +3,7 @@ import websockets
 import os
 
 async def handler():
-	async with websockets.connect('ws://localhost:' + os.environ['WEBSOCKETS_SERVER_PORT']) as websocket:
+	async with websockets.connect('ws://localhost:' + os.environ.get('WEBSOCKETS_SERVER_PORT', '5678')) as websocket:
 		while True:
 			message = await websocket.recv()
 			print(message)

--- a/emulate/sender.py
+++ b/emulate/sender.py
@@ -29,7 +29,7 @@ def get_fade_multiplier():
 		multiplier = delta_from_start / FADE_IN_TIME_MILLISECONDS
 	elif delta_to_end < FADE_OUT_TIME_MILLISECONDS:
 		multiplier = delta_to_end / FADE_OUT_TIME_MILLISECONDS
-	multiplier = 0.0 if multiplier < 0.0 else multiplier
+	multiplier = max(0.0, multiplier)
 	return multiplier
 
 
@@ -40,7 +40,7 @@ def update_dmx_values_fade(dmx_values):
 	dmx_values = ",".join([str(e) for e in dmx_values])
 	
 	save_to_redis_treshold = 0.0
-	if multiplier = save_to_redis_treshold:
+	if multiplier == save_to_redis_treshold:
 		save_dmx_values_to_redis(dmx_values)
 
 	return dmx_values

--- a/emulate/sender.py
+++ b/emulate/sender.py
@@ -29,14 +29,27 @@ def get_fade_multiplier():
 		multiplier = delta_from_start / FADE_IN_TIME_MILLISECONDS
 	elif delta_to_end < FADE_OUT_TIME_MILLISECONDS:
 		multiplier = delta_to_end / FADE_OUT_TIME_MILLISECONDS
+	multiplier = 0.0 if multiplier < 0.0 else multiplier
 	return multiplier
 
 
 def update_dmx_values_fade(dmx_values):
 	multiplier = get_fade_multiplier()
+	
 	dmx_values = [min(255, max(0, int(int(x) * (multiplier)))) for x in dmx_values.split(",")]
 	dmx_values = ",".join([str(e) for e in dmx_values])
+	
+	save_to_redis_treshold = 0.0
+	if multiplier = save_to_redis_treshold:
+		save_dmx_values_to_redis(dmx_values)
+
 	return dmx_values
+
+
+def save_dmx_values_to_redis(dmx_values):
+	redis_db.set('DMXvalues', dmx_values)
+	redis_db.set('DMXvalues_update_timestamp', current_milliseconds())
+
 	
 
 async def send_dmx_values(websocket, path):


### PR DESCRIPTION
Ogólnie to multiply miał wartość na minusie przez 1 klatkę, wtedy wartości dmx wchodziły na minus i przez to to losowe zachowanie. 

Nie było też zapisywania "zerowej" sceny do redisa po wygaśnięciu, co dodałem przy okazji :) 